### PR TITLE
Implement Jovial plugin POC

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Jovial Sonar Plugin
 
-This repository contains a minimal template for creating a custom language plugin for SonarQube. It defines a new language named **Jovial** and a stub sensor that can be extended with real analysis logic.
+This repository contains a minimal template for creating a custom language plugin for SonarQube. It defines a new language named **Jovial** and a simple sensor that demonstrates how rules can be executed on source files.
 
 ## Building
 
@@ -16,13 +16,14 @@ The build requires Java 11 and uses JUnit 5 for testing.
 
 `JovialSensor` is designed to communicate with **jovialserver**, a Python
 language server built with [pygls](https://github.com/openlawlibrary/pygls).
-The server is expected to run locally, and the sensor currently contains a
-placeholder connection block where analysis requests would be sent.
+For the POC the language server is replaced with a simple file reader but the
+integration points remain.
 
 ## Structure
 
 - `JovialPlugin` registers plugin extensions.
 - `JovialLanguage` declares the language key and file suffix.
-- `JovialSensor` is a placeholder sensor for analysis implementation.
+- `JovialSensor` executes a few demonstration rules.
+- `rules` package contains the example rule implementations.
 
 Feel free to extend these classes with additional functionality.

--- a/src/main/java/com/jovial/AST/ASTModel.java
+++ b/src/main/java/com/jovial/AST/ASTModel.java
@@ -1,4 +1,32 @@
 package com.jovial.AST;
 
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Very small AST model used for POC analysis.
+ * <p>
+ * TODO: replace this placeholder model with a full representation of the
+ * language. Nodes should include proper relationships (parent/child,
+ * expressions, types, etc.) and should be produced by a real parser or
+ * language server.
+ */
 public class ASTModel {
+    private final List<StatementNode> statements = new ArrayList<>();
+
+    public List<StatementNode> getStatements() {
+        return statements;
+    }
+
+    /**
+     * Create a basic model from raw source lines.
+     * Each line becomes a {@link StatementNode}.
+     */
+    public static ASTModel fromLines(List<String> lines) {
+        ASTModel model = new ASTModel();
+        for (int i = 0; i < lines.size(); i++) {
+            model.statements.add(new StatementNode(i + 1, lines.get(i)));
+        }
+        return model;
+    }
 }

--- a/src/main/java/com/jovial/AST/FunctionNode.java
+++ b/src/main/java/com/jovial/AST/FunctionNode.java
@@ -1,4 +1,25 @@
 package com.jovial.AST;
 
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Minimal representation of a function.
+ * TODO: include parameters, return types and proper scoping.
+ */
 public class FunctionNode {
+    private final String name;
+    private final List<StatementNode> body = new ArrayList<>();
+
+    public FunctionNode(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public List<StatementNode> getBody() {
+        return body;
+    }
 }

--- a/src/main/java/com/jovial/AST/README.md
+++ b/src/main/java/com/jovial/AST/README.md
@@ -1,1 +1,4 @@
-This Package might not be necessary - it is here as a template
+This package contains a very small AST model used for the proof of concept.
+
+The current classes only wrap raw source lines and provide minimal structure.
+A real implementation should introduce proper parsing and tree relationships.

--- a/src/main/java/com/jovial/AST/StatementNode.java
+++ b/src/main/java/com/jovial/AST/StatementNode.java
@@ -1,4 +1,23 @@
 package com.jovial.AST;
 
+/**
+ * Represents a single line of source code.
+ * TODO: expand with child nodes and token information once a real parser is integrated.
+ */
 public class StatementNode {
+    private final int line;
+    private final String text;
+
+    public StatementNode(int line, String text) {
+        this.line = line;
+        this.text = text;
+    }
+
+    public int getLine() {
+        return line;
+    }
+
+    public String getText() {
+        return text;
+    }
 }

--- a/src/main/java/com/jovial/plugin/JovialPlugin.java
+++ b/src/main/java/com/jovial/plugin/JovialPlugin.java
@@ -6,6 +6,7 @@ public class JovialPlugin implements Plugin {
     @Override
     public void define(Context context) {
         context.addExtension(JovialLanguage.class);
+        context.addExtension(JovialRulesDefinition.class);
         // JovialSensor performs analysis by talking to jovialserver (pygls based)
         context.addExtension(JovialSensor.class);
     }

--- a/src/main/java/com/jovial/plugin/JovialRulesDefinition.java
+++ b/src/main/java/com/jovial/plugin/JovialRulesDefinition.java
@@ -1,4 +1,19 @@
 package com.jovial.plugin;
 
-public class JovialRulesDefinition {
+import org.sonar.api.server.rule.RulesDefinition;
+import org.sonar.api.server.rule.RulesDefinition.NewRepository;
+
+/**
+ * Exposes the Jovial rules to SonarQube.
+ */
+public class JovialRulesDefinition implements RulesDefinition {
+    public static final String REPOSITORY = "jovial";
+
+    @Override
+    public void define(Context context) {
+        NewRepository repo = context.createRepository(REPOSITORY, JovialLanguage.KEY).setName("Jovial Rules");
+        repo.createRule("JOV001").setName("Avoid GOTO").setHtmlDescription("GOTO statements should be avoided");
+        repo.createRule("JOV002").setName("Line too long").setHtmlDescription("Lines should not exceed 120 characters");
+        repo.done();
+    }
 }

--- a/src/main/java/com/jovial/plugin/JovialSensor.java
+++ b/src/main/java/com/jovial/plugin/JovialSensor.java
@@ -3,6 +3,9 @@ package com.jovial.plugin;
 import org.sonar.api.batch.sensor.Sensor;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.batch.sensor.SensorDescriptor;
+import com.jovial.AST.ASTModel;
+import com.jovial.plugin.lsp.LSPRunner;
+import com.jovial.rules.base.RuleRegistry;
 import org.sonar.api.batch.fs.FileSystem;
 
 
@@ -21,14 +24,11 @@ public class JovialSensor implements Sensor {
 
     @Override
     public void execute(SensorContext context) {
-        fs.inputFiles(fs.predicates().all()).forEach(file -> {
-            if (!file.filename().endsWith(".jov")) return;
-
-//            ASTModel ast = LSPRunner.parseAST(file);
-//            if (ast != null) {
-//                NoGotoRule.apply(ast, file, context);
-//                // Add more rule calls here...
-//            }
+        fs.inputFiles(fs.predicates().hasLanguage(JovialLanguage.KEY)).forEach(file -> {
+            ASTModel ast = LSPRunner.parse(file);
+            if (ast != null) {
+                RuleRegistry.getRules().forEach(rule -> rule.apply(ast, file, context));
+            }
         });
     }
 }

--- a/src/main/java/com/jovial/plugin/README.md
+++ b/src/main/java/com/jovial/plugin/README.md
@@ -1,0 +1,9 @@
+Contains the SonarQube plugin entry points.
+
+Implemented components:
+- `JovialLanguage` declares basic language information.
+- `JovialSensor` runs the example rules on `.j73` files.
+- `JovialRulesDefinition` exposes rule metadata to SonarQube.
+
+Future work includes connecting to an actual language server and
+expanding the list of extensions.

--- a/src/main/java/com/jovial/plugin/lsp/LSPRunner.java
+++ b/src/main/java/com/jovial/plugin/lsp/LSPRunner.java
@@ -1,4 +1,24 @@
 package com.jovial.plugin.lsp;
 
-public class LSPRunner {
+import com.jovial.AST.ASTModel;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.List;
+import org.sonar.api.batch.fs.InputFile;
+
+/**
+ * Placeholder for language server integration.
+ * Currently it simply reads the file and builds a trivial AST model.
+ */
+public final class LSPRunner {
+    private LSPRunner() {}
+
+    public static ASTModel parse(InputFile file) {
+        try {
+            List<String> lines = Files.readAllLines(file.path());
+            return ASTModel.fromLines(lines);
+        } catch (IOException e) {
+            return null;
+        }
+    }
 }

--- a/src/main/java/com/jovial/plugin/lsp/README.md
+++ b/src/main/java/com/jovial/plugin/lsp/README.md
@@ -1,0 +1,5 @@
+Utilities for interacting with an external language server.
+
+The current implementation only reads the file contents locally.
+In a full implementation this class would start a language server process
+and exchange JSON-RPC messages.

--- a/src/main/java/com/jovial/rules/README.md
+++ b/src/main/java/com/jovial/rules/README.md
@@ -1,0 +1,4 @@
+This module contains all static analysis rules for the Jovial language.
+
+Rules are grouped in the `rulesets` package and registered through
+`RuleRegistry`.

--- a/src/main/java/com/jovial/rules/base/IssueReporter.java
+++ b/src/main/java/com/jovial/rules/base/IssueReporter.java
@@ -1,4 +1,27 @@
 package com.jovial.rules.base;
 
-public class IssueReporter {
+import org.sonar.api.batch.fs.InputFile;
+import org.sonar.api.batch.sensor.SensorContext;
+import org.sonar.api.batch.sensor.issue.NewIssue;
+import org.sonar.api.batch.sensor.issue.NewIssueLocation;
+import org.sonar.api.rule.RuleKey;
+import com.jovial.plugin.JovialRulesDefinition;
+
+/**
+ * Helper used by rules to report issues to SonarQube.
+ */
+public final class IssueReporter {
+    private IssueReporter() {
+    }
+
+    public static void reportIssue(SensorContext context, InputFile file, int line, String ruleKey, String message) {
+        RuleKey key = RuleKey.of(JovialRulesDefinition.REPOSITORY, ruleKey);
+        NewIssue issue = context.newIssue().forRule(key);
+        NewIssueLocation location = issue.newLocation().on(file).message(message);
+        if (line > 0) {
+            location.at(file.newRange(line, 0, line, 1));
+        }
+        issue.at(location);
+        issue.save();
+    }
 }

--- a/src/main/java/com/jovial/rules/base/README.md
+++ b/src/main/java/com/jovial/rules/base/README.md
@@ -1,0 +1,5 @@
+Base classes for the Jovial rule framework.
+
+They provide a minimal API for registering and executing rules. Further
+abstractions (configuration handling, rule parameters, etc.) can be
+implemented later.

--- a/src/main/java/com/jovial/rules/base/Rule.java
+++ b/src/main/java/com/jovial/rules/base/Rule.java
@@ -1,4 +1,14 @@
 package com.jovial.rules.base;
 
-public class Rule {
+import com.jovial.AST.ASTModel;
+import org.sonar.api.batch.fs.InputFile;
+import org.sonar.api.batch.sensor.SensorContext;
+
+/**
+ * Contract implemented by all Jovial rules.
+ */
+public interface Rule {
+    String key();
+
+    void apply(ASTModel ast, InputFile file, SensorContext context);
 }

--- a/src/main/java/com/jovial/rules/base/RuleRegistry.java
+++ b/src/main/java/com/jovial/rules/base/RuleRegistry.java
@@ -1,4 +1,23 @@
 package com.jovial.rules.base;
 
-public class RuleRegistry {
+import com.jovial.rules.rulesets.MaxLineLength;
+import com.jovial.rules.rulesets.NoGoto;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Stores all rules that should be executed by the sensor.
+ */
+public final class RuleRegistry {
+    private RuleRegistry() {
+    }
+
+    private static final List<Rule> RULES = Arrays.asList(
+            new NoGoto(),
+            new MaxLineLength()
+    );
+
+    public static List<Rule> getRules() {
+        return RULES;
+    }
 }

--- a/src/main/java/com/jovial/rules/rulesets/MaxLineLength.java
+++ b/src/main/java/com/jovial/rules/rulesets/MaxLineLength.java
@@ -8,19 +8,21 @@ import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.sensor.SensorContext;
 
 /**
- * Example rule that flags any use of 'goto'.
+ * Flags lines that exceed 120 characters.
  */
-public class NoGoto implements Rule {
+public class MaxLineLength implements Rule {
+    private static final int MAX_LENGTH = 120;
+
     @Override
     public String key() {
-        return "JOV001";
+        return "JOV002";
     }
 
     @Override
     public void apply(ASTModel ast, InputFile file, SensorContext context) {
         for (StatementNode stmt : ast.getStatements()) {
-            if (stmt.getText().trim().startsWith("goto")) {
-                IssueReporter.reportIssue(context, file, stmt.getLine(), key(), "Avoid using goto statements");
+            if (stmt.getText().length() > MAX_LENGTH) {
+                IssueReporter.reportIssue(context, file, stmt.getLine(), key(), "Line exceeds " + MAX_LENGTH + " characters");
             }
         }
     }

--- a/src/main/java/com/jovial/rules/rulesets/README.md
+++ b/src/main/java/com/jovial/rules/rulesets/README.md
@@ -1,0 +1,7 @@
+Example rule implementations used by the sensor.
+
+Currently implemented:
+- `NoGoto` reports usage of the `goto` statement.
+- `MaxLineLength` warns when a line is longer than 120 characters.
+
+More static analysis rules should be added in the future.

--- a/src/main/resources/org/sonar/l10n/jovial/rules/jovial.json
+++ b/src/main/resources/org/sonar/l10n/jovial/rules/jovial.json
@@ -5,5 +5,12 @@
     "status": "READY",
     "remediation": "10min",
     "description": "GOTO statements should be avoided."
+  },
+  "JOV002": {
+    "title": "Line too long",
+    "type": "CODE_SMELL",
+    "status": "READY",
+    "remediation": "5min",
+    "description": "Lines should not exceed 120 characters."
   }
 }


### PR DESCRIPTION
## Summary
- fill in placeholder AST classes with basic model
- implement rule framework and example rules
- wire up `JovialSensor` to execute rules
- add minimal language server stub
- register rules and add rule metadata
- document each package with READMEs

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684eecbabfe88320a15fdec5b3f343f2