### PR TITLE
Add POC rule implementation

### DIFF
--- a/src/main/java/com/jovial/AST/ASTModel.java
+++ b/src/main/java/com/jovial/AST/ASTModel.java
@@ -1,4 +1,14 @@
 package com.jovial.AST;
 
+/**
+ * Minimal representation of an Abstract Syntax Tree produced by the external
+ * language server. Only the structure required by demonstration rules is
+ * modelled here.
+ *
+ * TODO: replace this with a full fledged model once the real parser is
+ * available. The actual implementation should provide a tree of nodes with
+ * parents/children and rich type information.
+ */
 public class ASTModel {
+    // TODO: store root node and helper methods for traversal
 }

--- a/src/main/java/com/jovial/AST/FunctionNode.java
+++ b/src/main/java/com/jovial/AST/FunctionNode.java
@@ -1,4 +1,12 @@
 package com.jovial.AST;
 
+/**
+ * Placeholder node representing a function within the AST.
+ *
+ * TODO: add function name, parameters and body representation once the parser
+ * is available. This class should likely extend {@link StatementNode} in the
+ * real implementation.
+ */
 public class FunctionNode {
+    // TODO: fields describing function name and body
 }

--- a/src/main/java/com/jovial/AST/README.md
+++ b/src/main/java/com/jovial/AST/README.md
@@ -1,1 +1,12 @@
-This Package might not be necessary - it is here as a template
+This package contains placeholder classes representing the AST returned by the
+external Jovial language server. They are intentionally minimal and document
+what still needs to be implemented.
+
+* `ASTModel` - the root object for parsed files. Currently only a shell with
+  TODOs for a real tree representation.
+* `StatementNode` - generic statement placeholder.
+* `FunctionNode` - placeholder for a function definition.
+
+TODO:
+- Flesh out the node hierarchy with proper fields and relations.
+- Add parsing utilities once the LSP integration is ready.

--- a/src/main/java/com/jovial/AST/StatementNode.java
+++ b/src/main/java/com/jovial/AST/StatementNode.java
@@ -1,4 +1,12 @@
 package com.jovial.AST;
 
+/**
+ * Represents a single statement in the AST. This is intentionally very light
+ * weight for the POC and only provides a placeholder structure.
+ *
+ * TODO: add fields describing the type of statement, its text range and
+ * potential child statements.
+ */
 public class StatementNode {
+    // TODO: fields such as "type" and list of children
 }

--- a/src/main/java/com/jovial/plugin/JovialRulesDefinition.java
+++ b/src/main/java/com/jovial/plugin/JovialRulesDefinition.java
@@ -1,4 +1,33 @@
 package com.jovial.plugin;
 
-public class JovialRulesDefinition {
+import org.sonar.api.rules.RuleType;
+import org.sonar.api.server.rule.RulesDefinition;
+import org.sonar.api.server.rule.RulesDefinition.NewRepository;
+
+/**
+ * Minimal rules definition registering a couple of example rules. The messages
+ * for these rules are stored under resources in a JSON file.
+ */
+public class JovialRulesDefinition implements RulesDefinition {
+
+    /** Repository key under which Jovial rules are registered. */
+    public static final String REPOSITORY_KEY = "jovial";
+
+    @Override
+    public void define(Context context) {
+        NewRepository repo = context.createRepository(REPOSITORY_KEY, JovialLanguage.KEY)
+                .setName("Jovial Rules");
+
+        repo.createRule("JOV001")
+                .setName("Avoid GOTO")
+                .setHtmlDescription("GOTO statements should be avoided.")
+                .setType(RuleType.CODE_SMELL);
+
+        repo.createRule("JOV002")
+                .setName("No debug print")
+                .setHtmlDescription("Debug print statements should be removed.")
+                .setType(RuleType.CODE_SMELL);
+
+        repo.done();
+    }
 }

--- a/src/main/java/com/jovial/plugin/JovialSensor.java
+++ b/src/main/java/com/jovial/plugin/JovialSensor.java
@@ -4,6 +4,10 @@ import org.sonar.api.batch.sensor.Sensor;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.batch.sensor.SensorDescriptor;
 import org.sonar.api.batch.fs.FileSystem;
+import org.sonar.api.batch.fs.InputFile;
+
+import com.jovial.rules.base.Rule;
+import com.jovial.rules.base.RuleRegistry;
 
 
 public class JovialSensor implements Sensor {
@@ -21,14 +25,10 @@ public class JovialSensor implements Sensor {
 
     @Override
     public void execute(SensorContext context) {
-        fs.inputFiles(fs.predicates().all()).forEach(file -> {
-            if (!file.filename().endsWith(".jov")) return;
-
-//            ASTModel ast = LSPRunner.parseAST(file);
-//            if (ast != null) {
-//                NoGotoRule.apply(ast, file, context);
-//                // Add more rule calls here...
-//            }
+        fs.inputFiles(fs.predicates().hasLanguage(JovialLanguage.KEY)).forEach(file -> {
+            for (Rule rule : RuleRegistry.getAllRules()) {
+                rule.apply(file, context);
+            }
         });
     }
 }

--- a/src/main/java/com/jovial/plugin/README.md
+++ b/src/main/java/com/jovial/plugin/README.md
@@ -1,0 +1,12 @@
+This package contains the main SonarQube plugin classes for Jovial.
+
+Implemented components:
+- `JovialPlugin` registers the language and sensor.
+- `JovialLanguage` declares language key and suffix.
+- `JovialSensor` executes all registered rules on Jovial files.
+- `JovialRulesDefinition` exposes two demo rules.
+
+What's left:
+- Extend `JovialSensor` to communicate with the real language server via
+  `LSPRunner`.
+- Add more sophisticated rules and corresponding unit tests.

--- a/src/main/java/com/jovial/plugin/lsp/LSPRunner.java
+++ b/src/main/java/com/jovial/plugin/lsp/LSPRunner.java
@@ -1,4 +1,27 @@
 package com.jovial.plugin.lsp;
 
+import com.jovial.AST.ASTModel;
+import org.sonar.api.batch.fs.InputFile;
+
+/**
+ * Stub for communicating with the external "jovialserver" language server. In a
+ * real implementation this class would send the file contents to the server and
+ * receive a parsed AST. For now it simply returns {@code null}.
+ */
 public class LSPRunner {
+
+    private LSPRunner() {
+        // utility class
+    }
+
+    /**
+     * Parse the given file using the external language server.
+     *
+     * @param file Jovial source file
+     * @return parsed AST or {@code null} if parsing failed
+     */
+    public static ASTModel parseAST(InputFile file) {
+        // TODO connect to jovialserver via LSP and return a real AST model
+        return null;
+    }
 }

--- a/src/main/java/com/jovial/plugin/lsp/README.md
+++ b/src/main/java/com/jovial/plugin/lsp/README.md
@@ -1,0 +1,6 @@
+Contains the stub LSP runner used to communicate with the external Python
+`jovialserver`. At the moment it only exposes a static `parseAST` method that
+returns `null`.
+
+Future work will implement a real LSP client here to obtain AST models for
+analysis rules.

--- a/src/main/java/com/jovial/rules/README.md
+++ b/src/main/java/com/jovial/rules/README.md
@@ -1,0 +1,9 @@
+Rules infrastructure for the Jovial plugin.
+
+- `base` contains generic rule interfaces and utilities.
+- `rulesets` holds example rule implementations that demonstrate how analysis
+  could be performed without a real AST.
+
+Missing pieces:
+- More comprehensive rule implementations using the future AST model.
+- Configuration mechanism for enabling/disabling rulesets.

--- a/src/main/java/com/jovial/rules/base/IssueReporter.java
+++ b/src/main/java/com/jovial/rules/base/IssueReporter.java
@@ -1,4 +1,38 @@
 package com.jovial.rules.base;
 
-public class IssueReporter {
+import com.jovial.plugin.JovialRulesDefinition;
+import org.sonar.api.batch.fs.InputFile;
+import org.sonar.api.batch.sensor.SensorContext;
+import org.sonar.api.batch.sensor.issue.NewIssue;
+import org.sonar.api.batch.sensor.issue.NewIssueLocation;
+import org.sonar.api.rule.RuleKey;
+
+/**
+ * Helper used by rules to create issues in SonarQube.
+ */
+public final class IssueReporter {
+
+    private IssueReporter() {
+        // utility class
+    }
+
+    /**
+     * Report a new issue to SonarQube.
+     *
+     * @param context  sensor context
+     * @param file     source file
+     * @param line     line where the issue occurs
+     * @param message  description of the problem
+     * @param ruleKey  key of the rule that was violated
+     */
+    public static void reportIssue(SensorContext context, InputFile file, int line, String message, String ruleKey) {
+        RuleKey key = RuleKey.of(JovialRulesDefinition.REPOSITORY_KEY, ruleKey);
+        NewIssue issue = context.newIssue().forRule(key);
+        NewIssueLocation location = issue.newLocation()
+                .on(file)
+                .at(file.newRange(line, 0, line, 0))
+                .message(message);
+        issue.at(location);
+        issue.save();
+    }
 }

--- a/src/main/java/com/jovial/rules/base/README.md
+++ b/src/main/java/com/jovial/rules/base/README.md
@@ -1,0 +1,9 @@
+Base classes used by all Jovial rules.
+
+Currently provides:
+- `Rule` interface for rule implementations.
+- `IssueReporter` helper to create issues in SonarQube.
+- `RuleRegistry` which aggregates available rules.
+
+Future enhancements:
+- Support configurable rule parameters.

--- a/src/main/java/com/jovial/rules/base/Rule.java
+++ b/src/main/java/com/jovial/rules/base/Rule.java
@@ -1,4 +1,18 @@
 package com.jovial.rules.base;
 
-public class Rule {
+import org.sonar.api.batch.fs.InputFile;
+import org.sonar.api.batch.sensor.SensorContext;
+
+/**
+ * Interface for simple analysis rules executed by {@link com.jovial.plugin.JovialSensor}.
+ */
+public interface Rule {
+
+    /**
+     * Apply the rule to the given source file.
+     *
+     * @param inputFile jovial source file
+     * @param context sensor context to report issues
+     */
+    void apply(InputFile inputFile, SensorContext context);
 }

--- a/src/main/java/com/jovial/rules/base/RuleRegistry.java
+++ b/src/main/java/com/jovial/rules/base/RuleRegistry.java
@@ -1,4 +1,24 @@
 package com.jovial.rules.base;
 
-public class RuleRegistry {
+import com.jovial.rules.rulesets.BasicRuleset;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Provides access to all available rulesets.
+ */
+public final class RuleRegistry {
+
+    private RuleRegistry() {
+        // utility class
+    }
+
+    /**
+     * Gather all rules from the different rulesets.
+     */
+    public static List<Rule> getAllRules() {
+        List<Rule> rules = new ArrayList<>();
+        rules.addAll(BasicRuleset.getRules());
+        return rules;
+    }
 }

--- a/src/main/java/com/jovial/rules/rulesets/BasicRuleset.java
+++ b/src/main/java/com/jovial/rules/rulesets/BasicRuleset.java
@@ -1,0 +1,22 @@
+package com.jovial.rules.rulesets;
+
+import com.jovial.rules.base.Rule;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Example ruleset bundling simple demo rules.
+ */
+public final class BasicRuleset {
+
+    private BasicRuleset() {
+    }
+
+    public static List<Rule> getRules() {
+        return Arrays.asList(
+                new NoGoto(),
+                new NoPrintDebug()
+        );
+    }
+}

--- a/src/main/java/com/jovial/rules/rulesets/NoPrintDebug.java
+++ b/src/main/java/com/jovial/rules/rulesets/NoPrintDebug.java
@@ -9,24 +9,25 @@ import java.io.IOException;
 import java.nio.file.Files;
 
 /**
- * Very simple rule that flags usage of "goto" statements.
+ * Reports an issue whenever a call to `print` is encountered.
  */
-public class NoGoto implements Rule {
+public class NoPrintDebug implements Rule {
 
-    public static final String KEY = "JOV001";
+    public static final String KEY = "JOV002";
 
     @Override
     public void apply(InputFile inputFile, SensorContext context) {
         try {
             int lineNumber = 1;
             for (String line : Files.readAllLines(inputFile.path())) {
-                if (line.toLowerCase().contains("goto")) {
-                    IssueReporter.reportIssue(context, inputFile, lineNumber, "Avoid GOTO statements", KEY);
+                if (line.contains("print(")) {
+                    IssueReporter.reportIssue(context, inputFile, lineNumber,
+                            "Debug print statements should be removed", KEY);
                 }
                 lineNumber++;
             }
         } catch (IOException e) {
-            // ignore in POC
+            // ignore in this proof of concept
         }
     }
 }

--- a/src/main/java/com/jovial/rules/rulesets/README.md
+++ b/src/main/java/com/jovial/rules/rulesets/README.md
@@ -1,0 +1,7 @@
+Example rules implemented for the proof of concept plugin.
+
+- `NoGoto` reports any usage of a `goto` statement.
+- `NoPrintDebug` flags occurrences of `print()` used for debugging.
+- `BasicRuleset` exposes both rules so that the sensor can execute them.
+
+Additional rulesets can be added here as the AST model evolves.

--- a/src/main/resources/org/sonar/l10n/jovial/rules/jovial.json
+++ b/src/main/resources/org/sonar/l10n/jovial/rules/jovial.json
@@ -5,5 +5,12 @@
     "status": "READY",
     "remediation": "10min",
     "description": "GOTO statements should be avoided."
+  },
+  "JOV002": {
+    "title": "Remove debug prints",
+    "type": "CODE_SMELL",
+    "status": "READY",
+    "remediation": "5min",
+    "description": "Debug print statements should be removed."
   }
 }


### PR DESCRIPTION
## Summary
- flesh out plugin classes and add basic sensor logic
- add stub AST structures with TODO comments
- implement sample rules (NoGoto, NoPrintDebug) and a ruleset registry
- update rule definitions and l10n JSON
- document directories with README files

## Testing
- `mvn -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684eecbabfe88320a15fdec5b3f343f2